### PR TITLE
Preference Widget Tweaks (IST request)

### DIFF
--- a/lib_androidBits/src/main/java/com/blackmoonit/androidbits/widget/SliderPreference.java
+++ b/lib_androidBits/src/main/java/com/blackmoonit/androidbits/widget/SliderPreference.java
@@ -15,9 +15,6 @@ package com.blackmoonit.androidbits.widget;
  * limitations under the License.
  */
 
-import java.util.Arrays;
-import java.util.List;
-
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -29,6 +26,9 @@ import android.view.ViewGroup;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Custom preference that will toss up a slider dialog and store the result.<br>
@@ -43,7 +43,7 @@ import android.widget.TextView;
  * <br>
  * {@code android:positiveButtonText} &amp; {@code android:negativeButtonText} - optional,
  * {@literal @null} to hide the button, the resId if you want something other than
- * {@link android.R.string.ok} and {@link android.R.string.cancel}.<br>
+ * the standard "OK" and "CANCEL".<br>
  * <br>
  * {@code android:max} - optional max slider value. Default is 100. If entryValues are defined,
  * then the max is set to the number of entrys.<br>
@@ -51,8 +51,9 @@ import android.widget.TextView;
  * {@code android:dialogLayout} - optional in that if it is missing,
  * {@literal "@layout/dialog_pref_fontsize"} will be used.<br>
  * <br>
- * {@code android:dialogMessage} - optional in that if it is missing, the preference title
- * will be used.<br>
+ * {@code android:dialogMessage} &amp; {@code android:summary} &mdash;
+ *  optional; if missing, nothing will be displayed in the dialog above the
+ *  slider control.<br>
  * <br>
  * @author Ryan Fischbach
  */
@@ -90,17 +91,23 @@ public class SliderPreference extends DialogPreference implements OnSeekBarChang
 	}
 
 	/**
-	 * Descendants would override this method to expand the list of interested attributes.
-	 * Call super and expand on what it returns. Current list contains the entries:<br>
-	 * android.R.attr.entries<br>
-	 * android.R.attr.entryValues<br>
-	 * android.R.attr.defaultValue<br>
-	 * android.R.attr.positiveButtonText<br>
-	 * android.R.attr.negativeButtonText<br>
-	 * android.R.attr.max<br>
-	 * android.R.attr.dialogLayout<br>
-	 * android.R.attr.dialogMessage<br>
-	 *
+	 * Descendants would override this method to expand the list of interested
+     * attributes. Call {@code super.getAttrsWanted()} and expand on what it
+     * returns. Currently this list includes:
+     * <ul style="font-family:monospace">
+     * <li>android.R.attr.entries</li>
+     * <li>android.R.attr.entryValues</li>
+     * <li>android.R.attr.defaultValue</li>
+     * <li>android.R.attr.positiveButtonText</li>
+     * <li>android.R.attr.negativeButtonText</li>
+     * <li>android.R.attr.max</li>
+     * <li>android.R.attr.dialogLayout</li>
+     * </ul>
+	 * Note that there is an unresolved issue with some of the later items in
+     * this array, in that the resource IDs returned by the system are always
+     * the "default" (not found), even when those attributes are indeed supplied
+     * in the XML. One of these items, {@code dialogMessage}, has been removed
+     * as of 2016-01-15.
 	 * @return Complete list of attributes the class is interested in.
 	 */
 	protected int[] getAttrsWanted() {
@@ -111,8 +118,7 @@ public class SliderPreference extends DialogPreference implements OnSeekBarChang
 				android.R.attr.positiveButtonText,
 				android.R.attr.negativeButtonText,
 				android.R.attr.max,
-				android.R.attr.dialogLayout,
-				android.R.attr.dialogMessage,
+				android.R.attr.dialogLayout
 			};
 	}
 
@@ -122,8 +128,9 @@ public class SliderPreference extends DialogPreference implements OnSeekBarChang
 	 *
 	 * @param aAttrs - the attributes as defined in the xml file
 	 */
-	protected int processWantedAttributes(final TypedArray aAttrs) {
-		int i = 0;
+	protected int processWantedAttributes(final TypedArray aAttrs)
+    {
+        int i = 0;
 		R_array_pref_entries = aAttrs.getResourceId(i++,R_array_pref_entries);
 		R_array_pref_entryvalues = aAttrs.getResourceId(i++,R_array_pref_entryvalues);
 		if (mDefaultValue==null && aAttrs.peekValue(i)!=null)
@@ -133,12 +140,14 @@ public class SliderPreference extends DialogPreference implements OnSeekBarChang
 		setPositiveButtonText(aAttrs.getResourceId(i++,android.R.string.ok));
 		setNegativeButtonText(aAttrs.getResourceId(i++,android.R.string.cancel));
 		mSliderMaxValue = aAttrs.getInteger(i++,mSliderMaxValue);
-		setDialogLayoutResource(aAttrs.getResourceId(i++,getResId("layout","dialog_pref_slider")));
-		int theMsgResId = aAttrs.getResourceId(i++,-1);
-		if (theMsgResId==-1)
-			setDialogMessage(getTitle());
-		else
-			setDialogMessage(theMsgResId);
+		setDialogLayoutResource( aAttrs.getResourceId( i++,
+            getResId( "layout", "dialog_pref_slider" ) ) );
+        /*
+         * This method formerly tried to get things like the "dialogMessage" and
+         * "summary" but apparently those are intercepted and unavailable. Even
+         * the other attributes above, such as default value, are suspicious;
+         * "defaultValue" was also found to be unobtained.
+         */
 		return i;
 	}
 

--- a/lib_androidBits/src/main/res/layout/dialog_pref_slider.xml
+++ b/lib_androidBits/src/main/res/layout/dialog_pref_slider.xml
@@ -6,21 +6,23 @@
 <TextView android:id="@android:id/message" 
 	android:layout_height="wrap_content" android:layout_width="fill_parent" 
 	android:layout_alignParentTop="true"
+    android:paddingLeft="12dp"
+    android:paddingRight="12dp"
 	android:textColor="@android:color/primary_text_dark" 
 	android:text="MessageText"
-	></TextView>
+	/>
 <SeekBar android:id="@+id/dialog_pref_slider_SeekBar" 
 	android:layout_height="wrap_content" android:layout_width="fill_parent" 
 	android:layout_below="@android:id/message" 
 	android:max="100" 
 	android:layout_margin="12dip"
-	></SeekBar>
+	/>
 <TextView android:id="@+id/dialog_pref_slider_Summary" 
 	android:layout_height="wrap_content" android:layout_width="wrap_content" 
 	android:layout_below="@id/dialog_pref_slider_SeekBar" 
 	android:layout_alignLeft="@+id/dialog_pref_slider_SeekBar" 
 	android:textColor="@android:color/primary_text_dark" 
 	android:text="SummaryText"
-	></TextView>
+	/>
 
 </RelativeLayout>


### PR DESCRIPTION
A ticket from the IST Research backlog requested changes to preference widgets — specifically calling out `StringPreference` and `SliderPreference` — such that the "summary text", which was being used for help text, would be shown in the dialogs that popped up when the preferences were selected for editing.

In general, this turns out to have been a misunderstanding by the requestor as to which Android XML attribute would be used to define the text within the _dialog_. While `android:summary` does ordinarily define the help text shown on the preference list fragment, the help text inside the editor dialog is a different attribute — namely, `android:dialogMessage`. Thus, after discovering this, the implementation of this change took a different turn.
### `SliderPreference`

Many of the attributes that `SliderPreference` tries to process don't seem to be working. Most relevant to this change request was `android:dialogMessage`, whose resource ID seems to be intercepted by the OS and thus not accessible within the method. At least, it couldn't be fetched by any means we tried while implementing the change. However, if the widget code simply ignores it, the OS cheerfully renders the `android:dialogMessage` value within the `message` view of the layout (`dialog_pref_slider.xml`). Thus only the following changes were needed:
- In `SliderPreference#getAttrsWanted()`, remove the attributes that don't seem to be processed.
- In `SliderPreference#processWantedAttributes()`, remove code related to those attributes.
- In `dialog_pref_slider.xml`, add some left-right padding to the `message` view just for the sake of improved looks.
### `StringPreference`

No code changes were needed for `StringPreference`; instead, consumers of the widget should define help text using the `android:dialogMessage` parameter instead of `android:summary`.
### Test Case
1. Build and install any app that consumes `StringPreference` and `SliderPreference` and properly defines help text in `android:dialogMessage` attribute.
2. Run the app and navigate to the preferences screen.
3. Examine how the `StringPreference` is rendered.
   - **EXPECT:** The on-screen item contains the preference's name and one of the following:
     - The preference value, if defined and not a password.
     - A string of dots, if defined and used as a password.
     - A long blank (series of underscores), if not defined.
4. Tap the string preference.
   - **EXPECT:** The dialog renders the value of `android:dialogMessage`, if any, between the title and the edit box.
5. Change the value and tap **OK**.
   - **EXPECT:** Back on the preference list screen, the preference item shows the new value.
6. Examine how the `SliderPreference` is rendered.
   - **EXPECT:** The on-screen item contains the preference's name and current value, if any.
7. Tap the slider preference.
   - **EXPECT:** The dialog renders the value of `android:dialogMessage`, if any, between the title and the slider.
8. Change the value and tap **OK**.
   - **EXPECT:** Back on the preference list screen, the preference item shows the new value.
