### PR TITLE
API 23-Friendly MAC Address Static Methods

### DIFF
--- a/lib_androidBits/src/main/java/com/blackmoonit/androidbits/utils/BitsNetworkUtils.java
+++ b/lib_androidBits/src/main/java/com/blackmoonit/androidbits/utils/BitsNetworkUtils.java
@@ -231,8 +231,8 @@ public class BitsNetworkUtils
 
     /**
      * Returns the list of access points found in the most recent scan detected
-     * by device, even on those running Android API 23. Location must be enabled
-     * on device.
+     * by device, even on those running Android API 23. For those devices on
+     * Android API 23, Location must be enabled to have accurate results returned.
      * <p/>
      * This method makes calls that require
      * android.Manifest.permission.ACCESS_WIFI_STATE.
@@ -240,11 +240,11 @@ public class BitsNetworkUtils
      * In addition, calling application must have either
      * android.Manifest.permission.ACCESS_COARSE_LOCATION or
      * android.Manifest.permission.ACCESS_FINE_LOCATION in order to get valid
-     * results. Without one of these two permissions, and Location enabled on
-     * device, this method will return an empty list.
+     * results.
      * @param ctx Context Calling context.
-     * @return List<ScanResult> with found results, or empty list if needed
-     * permission(s) and location not enabled.
+     * @return List<ScanResult> with found results, or empty list on API 23
+     * devices if needed one of the needed permission(s) and location are not
+     * enabled.
      */
     public static List<ScanResult> getWifiScanResults( Context ctx )
     {


### PR DESCRIPTION
### What's New?

Implemented three new static BitsNetworkUtil methods that help get true MAC address values of various device hardware components, even on devices running API 23.
- [x] **`getWifiMacAddress( Context )`**: Returns device's true Wi-Fi MAC address, even on those running Android API 23. Returns device's Wi-Fi MAC address as a string, or an empty string when Wi-Fi is not supported on this device.
- [x] **`getBluetoothAdapterMacAddress( Context )`**: Returns device's true Bluetooth MAC address, even on those running Android API 23. Return device's Bluetooth MAC address as a string, or an empty string when Bluetooth is not supported on this device.
- [x] **`getWifiScanResults( Context )`**: Returns the list of access points found in the most recent scan detected by device, even on those running Android API 23. For those devices on Android API 23, Location must be enabled to have accurate results returned. Returns  a List of type `ScanResult` with found results, or on API 23 devices, an empty list, if needed permission(s) and location not enabled.
### How Do I Test This?

Read each methods' `javadoc` comments carefully, then use the three above methods as instructed. Check the boxes above once verified working as documented. 
